### PR TITLE
Remove padding when callout gets too small.

### DIFF
--- a/src/components/cms-components/SanityComponentsRenderer.astro
+++ b/src/components/cms-components/SanityComponentsRenderer.astro
@@ -44,7 +44,7 @@ const { content } = Astro.props;
       }
       case "callout": {
         return (
-          <ComponentWrapper>
+          <ComponentWrapper classes="py-0 xl:py-20 relative before:absolute before:-left-[3000px] before:bottom-0 before:right-[1000px] before:top-0 before:-z-10 before:w-[10000px] before:rounded-xl  marker:before:h-full">
             <Callout callout={content} />
           </ComponentWrapper>
         );

--- a/src/components/uielements/ComponentWrapper.astro
+++ b/src/components/uielements/ComponentWrapper.astro
@@ -8,7 +8,7 @@ const { classes, bgClass } = Astro.props;
 ---
 
 <div
-  class={`${bgClass ? `${bgClass} before:${bgClass}` : ""} ${classes ? classes : ""} py-8 md:py-20 relative before:absolute before:-left-[3000px] before:bottom-0 before:right-[1000px] before:top-0 before:-z-10 before:w-[10000px] before:rounded-xl  marker:before:h-full`}
+  class={`${bgClass ? `${bgClass} before:${bgClass}` : ""} ${classes ? classes : "py-8 md:py-20 relative before:absolute before:-left-[3000px] before:bottom-0 before:right-[1000px] before:top-0 before:-z-10 before:w-[10000px] before:rounded-xl  marker:before:h-full"} `}
 >
   <slot />
 </div>


### PR DESCRIPTION
Callout had padding under and above, this was not needed when it became to small and took the whole screen width.