### PR TITLE
use consts to define services work and blogpost pages (to avoid dupli…

### DIFF
--- a/src/api/queries.ts
+++ b/src/api/queries.ts
@@ -180,6 +180,10 @@ content[] {
       ...,
       defined(asset) => {
         asset->{...}
+      },
+      richText[] {
+        ...,
+        ${portableTextResolveInternalLink}
       }
     }
   },

--- a/src/components/uielements/Breadcrumbs.astro
+++ b/src/components/uielements/Breadcrumbs.astro
@@ -1,6 +1,11 @@
 ---
 import { parseHref } from "@lib/helpers";
-import { BASE_PATH } from "@src/consts";
+import {
+  BASE_PATH,
+  servicesPageName,
+  worksPageName,
+  insightsPageName,
+} from "@src/consts";
 import * as m from "@src/paraglide/messages";
 
 const basePathLength = BASE_PATH && BASE_PATH !== "" ? BASE_PATH.length + 1 : 1;
@@ -9,9 +14,9 @@ const pathNameAsLocale = Astro.url.pathname.substring(basePathLength);
 const paths = pathNameAsLocale.split("/").filter((x) => x);
 const locale = Astro.currentLocale!;
 
-const servicesPath = /\/services\/\S+/;
-const casesPath = /\/work\/\S+/;
-const insightsPath = /\/insights\/\S+/;
+const servicesPath = new RegExp(`/${servicesPageName}/\\S+`);
+const casesPath = new RegExp(`/${worksPageName}/\\S+`);
+const insightsPath = new RegExp(`/${insightsPageName}/\\S+`);
 
 let parts: { text: string; href: string }[] = [
   {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,3 +7,7 @@ export const VISUAL_EDITING_ENABLED =
   import.meta.env.SANITY_VISUAL_EDITING_ENABLED === "true" ||
   import.meta.env.SANITY_VISUAL_EDITING_ENABLED === true;
 export const BASE_PATH = import.meta.env.PUBLIC_ASTRO_BASE_PATH || "";
+
+export const servicesPageName = "services";
+export const insightsPageName = "insights";
+export const worksPageName = "work";

--- a/src/lib/sanityHelpers.ts
+++ b/src/lib/sanityHelpers.ts
@@ -1,5 +1,10 @@
 import type { Link } from "@sanity/sanity.types";
-import { BASE_PATH } from "@src/consts";
+import {
+  BASE_PATH,
+  insightsPageName,
+  servicesPageName,
+  worksPageName,
+} from "@src/consts";
 import type { LinkObjectReferenced } from "src/sanity/custom.sanity.types";
 
 export const getHrefFromLinkObject = (
@@ -11,9 +16,17 @@ export const getHrefFromLinkObject = (
     linkObject?.type === "internal" &&
     linkObject.internalLink &&
     (linkObject.internalLink?._type == "contentPage" ||
-      linkObject.internalLink._type == "service")
+      linkObject.internalLink._type == "service" ||
+      linkObject.internalLink._type == "blogPost" ||
+      linkObject.internalLink._type == "referenceCase")
   ) {
-    href = `${BASE_PATH}/${language}/${linkObject.internalLink.metadata?.slug?.current}`;
+    const subpage =
+      {
+        service: `${servicesPageName}/`,
+        blogPost: `${insightsPageName}/`,
+        referenceCase: `${worksPageName}/`,
+      }[linkObject.internalLink._type] || "";
+    href = `${BASE_PATH}/${language}/${subpage}${linkObject.internalLink.metadata?.slug?.current}`;
   } else if (linkObject?.type === "external") {
     href = linkObject.url || "";
     if (!href.startsWith("https://") && !href.startsWith("http://")) {

--- a/src/sanity/custom.sanity.types.ts
+++ b/src/sanity/custom.sanity.types.ts
@@ -1,19 +1,15 @@
 import type {
   AnswerQuestion,
-  Callout,
   CardGrid,
   CodeEmbed,
   CollaborationModel,
   CollabTab,
   Company,
   Cta,
-  Faq,
   Geopoint,
-  Highlight,
   internalGroqTypeReferenceTo,
   Intro,
   Link,
-  LongFormText,
   Metadata,
   ReferenceCase,
   SanityImageAsset,
@@ -22,7 +18,6 @@ import type {
   ServicePillar,
   ServicesCardList,
   SkosConcept,
-  Tabs,
   Technology,
   Testimonial,
   WorkCardList,
@@ -39,178 +34,10 @@ export interface LinkObjectReferenced {
   text?: string;
   type?: string;
   internalLink:
-    | {
-        _id: string;
-        _type: "company";
-        _createdAt: string;
-        _updatedAt: string;
-        _rev: string;
-        name?: string;
-        link?: Link;
-        logo?: {
-          default?: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          };
-          light?: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          };
-          dark?: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          };
-        };
-        content?: Array<
-          | ({
-              _key: string;
-            } & Callout)
-          | ({
-              _key: string;
-            } & CardGrid)
-          | ({
-              _key: string;
-            } & Highlight)
-          | ({
-              _key: string;
-            } & LongFormText)
-          | ({
-              _key: string;
-            } & ServicesCardList)
-          | ({
-              _key: string;
-            } & Tabs)
-          | ({
-              _key: string;
-            } & WorkCardList)
-        >;
-        type?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "skosConcept";
-        };
-        industryVertical?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "skosConcept";
-        };
-      }
-    | {
-        _id: string;
-        _type: "contentPage";
-        _createdAt: string;
-        _updatedAt: string;
-        _rev: string;
-        intro?: Intro;
-        content?: Array<
-          | ({
-              _key: string;
-            } & Callout)
-          | ({
-              _key: string;
-            } & CardGrid)
-          | ({
-              _key: string;
-            } & Highlight)
-          | ({
-              _key: string;
-            } & LongFormText)
-          | ({
-              _key: string;
-            } & ServicesCardList)
-          | ({
-              _key: string;
-            } & Tabs)
-          | ({
-              _key: string;
-            } & WorkCardList)
-        >;
-        metadata?: Metadata;
-        language?: string;
-      }
-    | {
-        _id: string;
-        _type: "service";
-        _createdAt: string;
-        _updatedAt: string;
-        _rev: string;
-        intro?: Intro;
-        image?: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        };
-        challenge?: string;
-        cta?: string;
-        content?: Array<
-          | ({
-              _key: string;
-            } & Callout)
-          | ({
-              _key: string;
-            } & CardGrid)
-          | ({
-              _key: string;
-            } & Highlight)
-          | ({
-              _key: string;
-            } & LongFormText)
-          | ({
-              _key: string;
-            } & ServicesCardList)
-          | ({
-              _key: string;
-            } & Tabs)
-          | ({
-              _key: string;
-            } & WorkCardList)
-        >;
-        faqs?: Faq;
-        customerReferences?: Array<{
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          _key: string;
-          [internalGroqTypeReferenceTo]?: "company";
-        }>;
-        servicePillar?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "servicePillar";
-        };
-        language?: string;
-        metadata?: Metadata;
-      }
+    | ContentPageWithReferences
+    | ServiceWithReferences
+    | BlogPostWithReferences
+    | ReferenceCaseReferenced
     | null;
   url?: string;
   email?: string;

--- a/src/scripts/generateTranslations.js
+++ b/src/scripts/generateTranslations.js
@@ -2,7 +2,9 @@ import "dotenv/config";
 import * as fs from "node:fs";
 import { sanityContentQuery } from "../scripts/sanityContentQuery.js";
 
-const locales = process.env.SANITY_LOCALES.split(", ");
+const locales = process.env.SANITY_LOCALES
+  ? process.env.SANITY_LOCALES.split(", ")
+  : ["en"];
 
 for (const locale of locales) {
   const { data: translations } = await sanityContentQuery({

--- a/src/scripts/sanityContentQuery.js
+++ b/src/scripts/sanityContentQuery.js
@@ -1,8 +1,6 @@
 import "dotenv/config";
 import { createClient } from "@sanity/client";
 
-const SANITY_VISUAL_EDITING_ENABLED = process.env.SANITY_VISUAL_EDITING_ENABLED;
-
 export function sanityCreateClient() {
   return createClient({
     projectId: process.env.SANITY_STUDIO_PROJECT_ID,


### PR DESCRIPTION
- use consts to define services work and blogpost pages (to avoid duplication), 
- update typings, 
- have default if sanity-locales is not array, 
- fix bug with links not resolving in references for callout richtext, 
- remove unused var, 
- fix portabletext links for service, 
- blogpost and reference cases internal links